### PR TITLE
200 secondary json parsing has no default and crashes queries

### DIFF
--- a/src/info/functions.rs
+++ b/src/info/functions.rs
@@ -32,7 +32,8 @@ mod testing {
         let species = "homo_sapiens";
         let taxon_id = 9606;
         let response = info(&search_terms, species, taxon_id);
-        assert!(response.is_err())
+        let info_results = response.unwrap();
+        assert!(info_results.0.is_empty());
     }
 
     #[test]

--- a/src/ncbi/functions/query_symbols.rs
+++ b/src/ncbi/functions/query_symbols.rs
@@ -48,7 +48,8 @@ mod testing {
         let symbols = vec!["BLAHBLAHBLAH".to_string()];
         let taxon_id = 9606;
         let response = query_symbols(&symbols, taxon_id);
-        assert!(response.is_err());
+        let ncbi_results = response.unwrap();
+        assert!(ncbi_results.0.is_empty());
     }
 
     #[test]

--- a/src/ncbi/functions/query_symbols.rs
+++ b/src/ncbi/functions/query_symbols.rs
@@ -1,4 +1,4 @@
-use crate::ncbi::types::NcbiResults;
+use crate::{ncbi::types::NcbiResults};
 use anyhow::{bail, Result};
 use reqwest::blocking::Client;
 use serde_json::Value;
@@ -24,7 +24,7 @@ pub fn query_symbols(symbols: &[String], taxon_id: usize) -> Result<NcbiResults>
             if result.0.len() > 0 {
                 Ok(result)
             } else {
-                bail!(format!("No results found for symbols: {:?}", symbols))
+                Ok(NcbiResults::default())
             }
         }
         None => bail!("Unable to parse response from NCBI"),

--- a/src/ncbi/types/container.rs
+++ b/src/ncbi/types/container.rs
@@ -4,7 +4,7 @@ use super::NcbiInfo;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct NcbiResults(pub HashMap<String, NcbiInfo>);
 
 impl NcbiResults {

--- a/src/uniprot/functions/query.rs
+++ b/src/uniprot/functions/query.rs
@@ -107,6 +107,7 @@ mod testing {
         let terms = vec!["AOSDKAPOWDNASD".to_string()];
         let taxon = None;
         let response = query(&terms, false, &taxon);
-        assert!(response.is_err());
+        let uniprot_results = response.unwrap();
+        assert!(uniprot_results.0.is_empty());
     }
 }

--- a/src/uniprot/functions/query.rs
+++ b/src/uniprot/functions/query.rs
@@ -1,5 +1,5 @@
 use crate::uniprot::types::{UniprotInfo, UniprotInfoContainer};
-use anyhow::{bail, Result};
+use anyhow::{Result};
 use futures::future::join_all;
 use reqwest::Client;
 use serde_json::Value;
@@ -83,11 +83,11 @@ pub fn query(
         .map(|x| (x.query.to_string(), x))
         .collect::<HashMap<String, UniprotInfo>>();
 
-    if results.len() > 0 {
-        Ok(UniprotInfoContainer(results))
+    Ok(if results.is_empty() {
+        UniprotInfoContainer::default()
     } else {
-        bail!(format!("Found no results for terms: {:?}", terms))
-    }
+        UniprotInfoContainer(results)
+    })
 }
 
 #[cfg(test)]

--- a/src/uniprot/types/uniprotinfo.rs
+++ b/src/uniprot/types/uniprotinfo.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt};
 
 // A container for UniprotInfo
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub struct UniprotInfoContainer(pub HashMap<String, UniprotInfo>);
 impl fmt::Display for UniprotInfoContainer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/utils/parsing.rs
+++ b/src/utils/parsing.rs
@@ -48,12 +48,15 @@ pub fn parse_secondary_string(value: &Value, primary: &str, secondary: &str) -> 
 /// Parses a vec from a json object from a secondary level
 #[must_use]
 pub fn parse_secondary_vec_string(value: &Value, primary: &str, secondary: &str) -> Vec<String> {
-    value[primary][secondary]
-        .as_array()
-        .unwrap_or_else(|| panic!("Missing: {}/{}", primary, secondary))
-        .iter()
-        .map(|x| x.as_str().expect("Non-string found in array").to_string())
-        .collect()
+    value.get(primary)
+        .and_then(|v| v.get(secondary))
+        .and_then(|v| v.as_array())
+        .map_or_else(
+            || Vec::new(),
+            |array| array.iter()
+                .map(|x| x.as_str().expect("Non-string found in array").to_string())
+                .collect()
+        )
 }
 
 /// Parses an optional vec from a json object from a secondary level


### PR DESCRIPTION
Updating the result contains structs to have defaults so if the query in async multi queries fails, the entire process does not fail; instead, an empty result is returned. If this is not the desired behavior for whatever reason, I am happy to keep this as a separate branch. This was just very useful for my use case.